### PR TITLE
Parsing a WKB as binary instead of String

### DIFF
--- a/examples/pigeon_import.pig
+++ b/examples/pigeon_import.pig
@@ -31,3 +31,5 @@ DEFINE ST_XMin edu.umn.cs.pigeon.XMin;
 DEFINE ST_XMax edu.umn.cs.pigeon.XMax;
 DEFINE ST_YMin edu.umn.cs.pigeon.YMin;
 DEFINE ST_YMax edu.umn.cs.pigeon.YMax;
+DEFINE ST_ESRIFromWKB edu.umn.cs.pigeon.ESRIShapeFromWKB;
+DEFINE ST_ESRIFromText edu.umn.cs.pigeon.ESRIShapeFromText;

--- a/src/main/java/edu/umn/cs/pigeon/ESRIShapeFromText.java
+++ b/src/main/java/edu/umn/cs/pigeon/ESRIShapeFromText.java
@@ -1,0 +1,32 @@
+/*******************************************************************
+ * Copyright (C) 2014 by Regents of the University of Minnesota.   *
+ *                                                                 *
+ * This Software is released under the Apache License, Version 2.0 *
+ * http://www.apache.org/licenses/LICENSE-2.0                      *
+ *******************************************************************/
+package edu.umn.cs.pigeon;
+
+import java.io.IOException;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.Tuple;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+
+/**
+ * @author Carlos Balduz
+ *
+ */
+public class ESRIShapeFromText extends EvalFunc<DataByteArray> {
+    
+  @Override
+  public DataByteArray exec(Tuple input) throws IOException {
+              
+    if (input.size() != 1) 
+        throw new IOException("ESRIShapeFromText takes one bytearray argument");
+
+    String s = input.get(0).toString();
+    return new DataByteArray(OGCGeometryToESRIShapeParser.ogcGeomToEsriShape(s)); 
+  }
+}

--- a/src/main/java/edu/umn/cs/pigeon/ESRIShapeFromWKB.java
+++ b/src/main/java/edu/umn/cs/pigeon/ESRIShapeFromWKB.java
@@ -1,0 +1,30 @@
+/*******************************************************************
+ * Copyright (C) 2014 by Regents of the University of Minnesota.   *
+ *                                                                 *
+ * This Software is released under the Apache License, Version 2.0 *
+ * http://www.apache.org/licenses/LICENSE-2.0                      *
+ *******************************************************************/
+package edu.umn.cs.pigeon;
+
+import java.io.IOException;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.Tuple;
+
+/**
+ * @author Carlos Balduz
+ *
+ */
+public class ESRIShapeFromWKB extends EvalFunc<DataByteArray> {
+    
+  @Override
+  public DataByteArray exec(Tuple input) throws IOException {
+              
+    if (input.size() != 1) 
+        throw new IOException("ESRIShapeFromWKB takes one bytearray argument");
+
+    Object o = input.get(0);
+    return new DataByteArray(OGCGeometryToESRIShapeParser.ogcGeomToEsriShape(o)); 
+  }
+}

--- a/src/main/java/edu/umn/cs/pigeon/GeometryFromWKB.java
+++ b/src/main/java/edu/umn/cs/pigeon/GeometryFromWKB.java
@@ -27,7 +27,7 @@ public class GeometryFromWKB extends EvalFunc<DataByteArray> {
         throw new IOException("GeometryFromWKB takes one bytearray argument");
     
     ESRIGeometryParser gp = new ESRIGeometryParser();
-    OGCGeometry geom = gp.parseGeom(input.get(0).toString());
+    OGCGeometry geom = gp.parseGeom(input.get(0));
     return new DataByteArray(geom.asBinary().array()); 
   }
 }

--- a/src/main/java/edu/umn/cs/pigeon/OGCGeometryToESRIShapeParser.java
+++ b/src/main/java/edu/umn/cs/pigeon/OGCGeometryToESRIShapeParser.java
@@ -32,7 +32,7 @@ public class OGCGeometryToESRIShapeParser {
 
     System.arraycopy(shape, 0, shapeWithData, SIZE_WKID + SIZE_TYPE, shape.length);    
     System.arraycopy(intToBytes(wkid), 0, shapeWithData, 0, SIZE_WKID);
-    shapeWithData[SIZE_WKID] = (byte) type;
+    shapeWithData[SIZE_WKID] = (byte) geomType;
 
     return shapeWithData;
   }

--- a/src/main/java/edu/umn/cs/pigeon/OGCGeometryToESRIShapeParser.java
+++ b/src/main/java/edu/umn/cs/pigeon/OGCGeometryToESRIShapeParser.java
@@ -1,0 +1,78 @@
+/*******************************************************************
+ * Copyright (C) 2014 by Regents of the University of Minnesota.   *
+ *                                                                 *
+ * This Software is released under the Apache License, Version 2.0 *
+ * http://www.apache.org/licenses/LICENSE-2.0                      *
+ *******************************************************************/
+package edu.umn.cs.pigeon;
+
+import org.apache.pig.backend.executionengine.ExecException;
+import org.apache.pig.data.DataByteArray;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.esri.core.geometry.GeometryEngine;
+
+/**
+ * Converts an OGCGeometry to an ESRI Shape byte array so it can later be used
+ * in Hive without the need to perform additional parsings in Hive.
+ * @author Carlos Balduz
+ */
+public class OGCGeometryToESRIShapeParser {
+  private static final int SIZE_WKID = 4;
+  private static final int SIZE_TYPE = 1;
+
+  public static byte[] ogcGeomToEsriShape(Object o) throws ExecException {
+    ESRIGeometryParser parser = new ESRIGeometryParser();
+    OGCGeometry geom = parser.parseGeom(o);
+    int wkid = geom.SRID();
+    int geomType = getGeometryType(geom);
+
+    byte[] shape = GeometryEngine.geometryToEsriShape(geom.getEsriGeometry());
+    byte[] shapeWithData = new byte[shape.length + SIZE_TYPE + SIZE_WKID];
+
+    System.arraycopy(shape, 0, shapeWithData, SIZE_WKID + SIZE_TYPE, shape.length);    
+    System.arraycopy(intToBytes(wkid), 0, shapeWithData, 0, SIZE_WKID);
+    shapeWithData[SIZE_WKID] = (byte) type;
+
+    return shapeWithData;
+  }
+
+  /**
+   * Convert int to byte array.
+   * @param i
+   * @return
+   */
+  private static byte[] intToBytes(int value) {
+    return new byte[] {
+      (byte) (value >>> 24),
+      (byte) (value >>> 16),
+      (byte) (value >>> 8),
+      (byte) value
+    };
+  }
+
+  /**
+   * Get the geometry type of a OGCGeometry object.
+   * @param i
+   * @return
+   */
+  private static int getGeometryType(OGCGeometry geom) {
+    String typeName = geom.geometryType();
+    int ogcType = 0;
+
+    if (typeName.equals("Point"))
+      ogcType = 1;
+    else if (typeName.equals("LineString"))
+      ogcType = 2;
+    else if (typeName.equals("Polygon"))
+      ogcType = 3;
+    else if (typeName.equals("MultiPoint"))
+      ogcType = 4;
+    else if (typeName.equals("MultiLineString"))
+      ogcType = 5;
+    else if (typeName.equals("MultiPolygon"))
+      ogcType = 6;
+
+    return ogcType;
+  }
+}


### PR DESCRIPTION
The UDF to parse a Geometry from a WKB was calling toString on the
bytearray, attempting to parse a String instead of the bytearray in
ESRIGeometryParser. With scripts like:
```
A = load 'a';
B = foreach A generate ST_GeomFromWKB(ST_GeomFromText($0));
store B into 'b';
```
It resulted in:
```
ERROR 0: Cannot parse '>@I@'
```