### PR TITLE
Handle exceptions in IsValid operator

### DIFF
--- a/src/main/java/edu/umn/cs/pigeon/IsValid.java
+++ b/src/main/java/edu/umn/cs/pigeon/IsValid.java
@@ -34,7 +34,12 @@ public class IsValid extends FilterFunc {
       geom = geometryParser.parseGeom(v);
       return geom.isValid();
     } catch (ExecException ee) {
-      throw new GeoException(geom, ee);
+      return false;
+    } catch (IllegalArgumentException iae) {
+      // ParseGeom can throw an IllegalArgumentException 
+      // (e.g., java.lang.IllegalArgumentException: Invalid number of points 
+      // in LinearRing (found 3 - must be 0 or >= 4))
+      return false;
     }
   }
 


### PR DESCRIPTION
When an invalid geometry is passed to the IsValid operator, exceptions can be thrown by the `geometryParser.parseGeom(v)` method. For example:

`
java.lang.IllegalArgumentException: Invalid number of points in LinearRing (found 3 - must be 0 or >= 4))
`

These exceptions are not caught and cause the entire Hadoop job to fail. The IsValid operator should be able to work with defective geometries and not throw any exceptions. 

This PR changes the behavior of the operator accordingly. This operator can now filter broken geometries that throw an exception.